### PR TITLE
Simplify map confirmation flow for email link

### DIFF
--- a/MAP_DEBUGGING.md
+++ b/MAP_DEBUGGING.md
@@ -1,0 +1,73 @@
+# Map Loading Debug Guide
+
+## Issue Fixed
+The "Cargando Mapa" (Loading Map) state was getting stuck when clicking location links. This has been fixed with the following improvements:
+
+## Changes Made
+
+### 1. Enhanced Error Handling
+- Added comprehensive debug logging throughout the map initialization process
+- Added fallback mechanisms to prevent infinite loading states
+- Improved error messages to help identify specific issues
+
+### 2. Fixed Google Maps API Loading
+- Added proper error handling for API loading failures
+- Added fallback API key handling (uses 'DEMO_KEY' if not configured)
+- Improved script loading detection and callback handling
+
+### 3. Fixed Map Initialization
+- Added fallback from AdvancedMarkerElement to regular Marker if not available
+- Fixed event listener handling to prevent TypeScript errors
+- Added proper cleanup of event listeners
+- Ensured `mapLoaded` state is always set to prevent infinite loading
+
+### 4. Added Debug Logging
+The following debug messages are now logged to the browser console:
+- `[DEBUG] loadGoogleMapsAPI called`
+- `[DEBUG] Google Maps API loaded, initializing map...`
+- `[DEBUG] Container found, starting map initialization process...`
+- `[DEBUG] Container not ready, retrying in 100ms... (X/50)`
+- `[DEBUG] Map instance created successfully`
+- `[DEBUG] Map is idle, creating marker...`
+- `[DEBUG] Map loaded successfully`
+- `[DEBUG] Container became available, retrying map initialization...`
+
+## Environment Setup
+
+To ensure the map works properly, create a `.env.local` file in the project root with:
+
+```env
+# Google Maps API Key (required for map functionality)
+VITE_GOOGLE_MAPS_API_KEY=your-google-maps-api-key-here
+```
+
+## Testing the Fix
+
+1. Open the browser developer console (F12)
+2. Click on a location link
+3. Watch the console for debug messages
+4. The map should now load properly instead of getting stuck on "Cargando Mapa"
+
+## Common Issues and Solutions
+
+### Issue: "Google Maps API not fully loaded"
+**Solution**: Check that `VITE_GOOGLE_MAPS_API_KEY` is set in your environment variables
+
+### Issue: "No container found for map"
+**Solution**: The code now automatically retries waiting for the container to become available (up to 5 seconds). This handles React timing issues where the useEffect runs before the DOM element is mounted.
+
+### Issue: "AdvancedMarkerElement not available"
+**Solution**: The code will automatically fallback to regular Google Maps Marker
+
+### Issue: Map loads but no marker appears
+**Solution**: Check the console for marker creation errors - the map will still load but without a draggable marker
+
+## Debug Information
+
+The enhanced logging will help identify exactly where the map loading process fails:
+- API loading issues
+- Map initialization problems
+- Marker creation failures
+- Event listener problems
+
+All errors are now properly caught and the `mapLoaded` state is set to prevent infinite loading states.


### PR DESCRIPTION
## Summary
- streamline the email confirmation landing page to focus on an interactive map and draggable marker
- automatically request the recipient's device location and disable other edit actions so only the marker position is submitted
- show a dedicated thank-you screen after submission with no follow-up actions available

## Testing
- npm run lint *(fails: existing lint errors across repo, including legacy any-typed code)*

------
https://chatgpt.com/codex/tasks/task_e_68cccea33048832e870433eee4d33266